### PR TITLE
Fixed The Empty Add Friend Modal Bug - Closes Issue 46

### DIFF
--- a/SocialMediaApp.MVC/Hubs/NotificationHub.cs
+++ b/SocialMediaApp.MVC/Hubs/NotificationHub.cs
@@ -33,10 +33,13 @@ public class NotificationHub : Hub
     [Authorize]
     public async Task<string> SendFriendNotification(string username, string email)
     {
+        if ((username is null || username == "") && (email is null || email == ""))
+            return ("You need to fill the modal before submitting it.|danger");
+
         AppUser appUser = await _authenticationProcedures.GetCurrentUserAsync();
         AppUser friend;
         if (username != "" || username is not null)
-            friend = await _authenticationProcedures.FindByUsernameAsync(username);
+            friend = await _authenticationProcedures.FindByUsernameAsync(username!);
         else
             friend = await _authenticationProcedures.FindByEmailAsync(email);
 


### PR DESCRIPTION
After this update the app does not crash after an empty value is submited in the modal and if that value is provided then the user receives an appropriate error message.