### PR TITLE
Added Google External Identity Provider - Closes Issue 53

### DIFF
--- a/SocialMediaApp.AuthenticationLibrary/IAuthenticationProcedures.cs
+++ b/SocialMediaApp.AuthenticationLibrary/IAuthenticationProcedures.cs
@@ -1,4 +1,5 @@
-﻿using SocialMediaApp.SharedModels;
+﻿using Microsoft.AspNetCore.Authentication;
+using SocialMediaApp.SharedModels;
 
 namespace SocialMediaApp.AuthenticationLibrary
 {
@@ -12,10 +13,13 @@ namespace SocialMediaApp.AuthenticationLibrary
         Task<string> CreateChangeEmailTokenAsync(AppUser appUser, string newEmail);
         Task<string> CreateResetPasswordTokenAsync(AppUser appUser);
         Task<bool> DeleteUserAccountAsync(AppUser appUser);
+        Task<string> ExternalSignInUserAsync();
         Task<AppUser> FindByEmailAsync(string email);
         Task<AppUser> FindByUserIdAsync(string userId);
         Task<AppUser> FindByUsernameAsync(string username);
         Task<AppUser> GetCurrentUserAsync();
+        Task<IEnumerable<AuthenticationScheme>> GetExternalIdentityProvidersAsync();
+        AuthenticationProperties GetExternalIdentityProvidersPropertiesAsync(string identityProviderName, string redirectUrl);
         Task<List<AppUser>> GetUsersAsync();
         Task LogOutUserAsync();
         Task<(string, string)> RegisterUserAsync(AppUser appUser, string password, bool isPersistent);

--- a/SocialMediaApp.AuthenticationLibrary/SocialMediaApp.AuthenticationLibrary.csproj
+++ b/SocialMediaApp.AuthenticationLibrary/SocialMediaApp.AuthenticationLibrary.csproj
@@ -15,6 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="7.0.17" />
     <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.16" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.16" />

--- a/SocialMediaApp.MVC/Models/SignInModel.cs
+++ b/SocialMediaApp.MVC/Models/SignInModel.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using Microsoft.AspNetCore.Authentication;
+using System.ComponentModel.DataAnnotations;
 
 namespace SocialMediaApp.MVC.Models;
 
@@ -9,4 +10,6 @@ public class SignInModel
     [Required(ErrorMessage = "This field is required")]
     public string? Password { get; set; }
     public bool RememberMe { get; set; }
+    public string? ReturnUrl { get; set; }
+    public List<AuthenticationScheme> ExternalIdentityProviders { get; set; } = new List<AuthenticationScheme>();
 }

--- a/SocialMediaApp.MVC/Program.cs
+++ b/SocialMediaApp.MVC/Program.cs
@@ -57,6 +57,12 @@ public class Program
             options.Cookie.HttpOnly = true; // Make the cookie accessible only through HTTP (not JavaScript) for security reasons
         });
 
+        builder.Services.AddAuthentication().AddGoogle(options =>
+        {
+            options.ClientId = configuration.GetValue<string>("Authentication:Google:ClientId")!;
+            options.ClientSecret = configuration.GetValue<string>("Authentication:Google:ClientSecret")!;
+        });
+
         builder.Services.AddScoped<IAuthenticationProcedures, AuthenticationProcedures>();
         builder.Services.AddScoped<IPostDataAccess, PostDataAccess>();
         builder.Services.AddScoped<IMessageDataAccess, MessageDataAccess>();
@@ -81,6 +87,7 @@ public class Program
 
         app.UseRouting();
 
+        app.UseAuthentication();
         app.UseAuthorization();
 
         app.MapControllerRoute(

--- a/SocialMediaApp.MVC/SocialMediaApp.MVC.csproj
+++ b/SocialMediaApp.MVC/SocialMediaApp.MVC.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>fbde58c8-1347-4fb0-87d0-4790858836f8</UserSecretsId>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/SocialMediaApp.MVC/Views/Account/EditAccount.cshtml
+++ b/SocialMediaApp.MVC/Views/Account/EditAccount.cshtml
@@ -139,17 +139,27 @@ else if (basicInformationChangeSuccess || passwordChangeSuccess || friendRemoval
             <div class="row">
                 <h4 class="text-center">Sensitive Account Settings</h4>
                 <div class="col-12 mb-4 mt-1">
-                    <label class="form-label" asp-for="@Model.ChangePasswordModel.OldPassword">
-                        <i class="fa-solid fa-lock me-2"></i>Account Password
-                    </label>
-                    <div class="input-group">
+                    @if(Model.ChangePasswordModel.OldPassword is not null){
+                        <label class="form-label" asp-for="@Model.ChangePasswordModel.OldPassword">
+                            <i class="fa-solid fa-lock me-2"></i>Account Password
+                        </label>
+                        <div class="input-group">
+                            <input type="password" class="form-control" asp-for="@Model.ChangePasswordModel.OldPassword"
+                                   value="@Model.ChangePasswordModel.OldPassword" readOnly>
+                            <a class="btn btn-outline-primary" data-bs-toggle="modal" data-bs-target="#changePasswordModal">
+                                <i class="fa-solid fa-pencil"></i>
+                            </a>
+                        </div>
+                        <span asp-validation-for="@Model.ChangePasswordModel.OldPassword" class="text-danger"></span>
+                    }
+                    else
+                    {
+                        <label class="form-label" asp-for="@Model.ChangePasswordModel.OldPassword">
+                            <i class="fa-solid fa-lock me-2"></i>Account Password - Managed By External Provider
+                        </label>
                         <input type="password" class="form-control" asp-for="@Model.ChangePasswordModel.OldPassword"
-                               value="@Model.ChangePasswordModel.OldPassword" readOnly>
-                        <a class="btn btn-outline-primary" data-bs-toggle="modal" data-bs-target="#changePasswordModal">
-                            <i class="fa-solid fa-pencil"></i>
-                        </a>
-                    </div>
-                    <span asp-validation-for="@Model.ChangePasswordModel.OldPassword" class="text-danger"></span>
+                                   value="ManagedByExternalProvider" readOnly>
+                    }
                 </div>
                 <div class="col-12 mb-4 mt-1">
                     <label class="form-label" asp-for="@Model.ChangeEmailModel.OldEmail">

--- a/SocialMediaApp.MVC/Views/Account/SignIn.cshtml
+++ b/SocialMediaApp.MVC/Views/Account/SignIn.cshtml
@@ -2,11 +2,12 @@
     ViewData["Title"] = "Sign In";
     bool falseResetAccount = (bool)ViewData["FalseResetAccount"]!;
     bool invalidCredentials = (bool)ViewData["InvalidCredentials"]!;
+    string externalIdentityProviderError = (string)ViewData["externalIdentityProviderError"]!;
 }
 
 @model SignInModel
 
-@if (falseResetAccount || invalidCredentials)
+@if (falseResetAccount || invalidCredentials || externalIdentityProviderError != null)
 {
     <svg xmlns="http://www.w3.org/2000/svg" class="d-none">
         <symbol id="exclamation-triangle-fill" viewBox="0 0 16 16">
@@ -27,25 +28,29 @@
         {
             <div>There is no user with the given credentials or the account is not yet activated.</div>
         }
+        else if(externalIdentityProviderError != null)
+        {
+            <div>@externalIdentityProviderError</div>
+        }
         <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
     </div>
 }
 
 <div class="row">
     <div class="offset-4 col-4 shadow p-4" style="background-color:white;">
-        <h2 class="text-center mb-4">User Login</h2>
+        <h2 class="text-center mb-3">User Login</h2>
         <form method="post">
-            <div class="mb-4 mt-1">
+            <div class="mb-3">
                 <label asp-for="Username"><i class="fa-solid fa-user me-2"></i>Username</label>
                 <input class="form-control" asp-for="Username" placeholder="Enter username">
                 <span asp-validation-for="Username" class="text-danger"></span>
             </div>
-            <div class="mt-1">
+            <div class="mb-2">
                 <label asp-for="Password"><i class="fa-solid fa-lock me-2"></i>Password</label>
                 <input class="form-control" asp-for="Password" type="password" placeholder="Enter password">
                 <span asp-validation-for="Password" class="text-danger"></span>
             </div>
-            <div class="d-flex justify-content-between mt-2">
+            <div class="d-flex justify-content-between">
                 <div class="form-check">
                     <label class="form-check-label" asp-for="RememberMe">Remember Me</label>
                     <input class="form-check-input" type="checkbox" asp-for="RememberMe">
@@ -53,14 +58,45 @@
                 <a href="#" class="text-decoration-none" data-bs-toggle="modal" data-bs-target="#forgotPasswordModal">Forgot Password?</a>
             </div>
 
-            <div class="d-flex justify-content-center mt-5">
+            <div class="d-flex justify-content-center mt-4">
                 <button type="submit" class="btn btn-primary" style="width: 70%;">Sign In</button>
             </div>
             <div class="text-center mt-1">
                 <a asp-controller="Account" asp-action="SignUp" class="text-decoration-none">Not registered yet? Sign Up Now!</a>
             </div>
-
         </form>
+        <div>
+            <div class="d-flex justify-content-center align-items-center my-2">
+                <div class="flex-grow-1">
+                    <hr class="my-3">
+                </div>
+                <div class="px-3">
+                    <span>OR</span>
+                </div>
+                <div class="flex-grow-1">
+                    <hr class="my-3">
+                </div>
+            </div>
+
+            <form asp-controller="account" asp-action="ExternalLogin">
+                <div id="external-service-providers" class="d-grid gap-2">
+                    @foreach (AuthenticationScheme identityProvider in Model.ExternalIdentityProviders)
+                    {
+                        <button class="btn text-start py-2 px-3" style="background-color:transparent;border: 1px solid #ced4da;" type="submit"
+                            name="identityProviderName" value="@identityProvider.Name">
+                            <i class="fa-brands fa-google me-2"></i>Continue with @identityProvider.DisplayName
+                        </button>
+                    }
+                    <button class="btn text-start py-2 px-3" style="background-color:transparent;border: 1px solid #ced4da;" type="button">
+                        <i class="fa-brands fa-microsoft me-2"></i>Continue with Microsoft
+                    </button>
+                    <button class="btn text-start py-2 px-3" style="background-color:transparent;border: 1px solid #ced4da;" type="button">
+                        <i class="fa-brands fa-square-facebook me-2"></i>Continue with Facebook
+                    </button>
+                </div>
+                <input name="returnUrl" value="@Model.ReturnUrl" hidden/>
+            </form>
+        </div>
 
         <div class="modal fade" id="forgotPasswordModal" tabindex="-1" role="dialog" aria-labelledby="forgotPasswordModalLabel" aria-hidden="true">
             <div class="modal-dialog" role="document">

--- a/SocialMediaApp.MVC/Views/Shared/_Layout.cshtml
+++ b/SocialMediaApp.MVC/Views/Shared/_Layout.cshtml
@@ -39,7 +39,7 @@
                             <a class="nav-link" asp-controller="Home" asp-action="Index">Home</a>
                         </li>
 
-                        @if (!(await _authenticationProcedures.CheckIfUserIsLoggedIn()))
+                        @if (appUser is null)
                         {
                             <li class="nav-item">
                                 <a class="nav-link btn btn-outline-primary my-2 my-sm-0" asp-controller="Account" asp-action="SignIn">Sign In</a>
@@ -51,9 +51,11 @@
                                 <a class="nav-link" asp-controller="Chat" asp-action="ViewChats">Chats</a>
                             </li>
                             <li class="nav-item" id="notificationSection">
+                                
                                 <a class="nav-link" asp-controller="Notification" asp-action="ViewNotifications">
                                     Notifications <span class="badge bg-primary rounded-pill" id="notificationSectionBadgeCount">
-                                        @appUser!.Notifications.Count</span>
+                                        @appUser!.Notifications!.Count
+                                    </span>
                                 </a>
                             </li>
                             <li class="nav-item">
@@ -102,7 +104,6 @@
             let notificationSection = document.getElementById('notificationSection');
             if (notificationSection !== null) {
                 connection.start().then(function () {
-                    console.log(".....SignalRsucks.....");
                     storeConnectionSignalRId();
                 }).catch(function (err) {
                     console.error("Error establishing SignalR connection: " + err);

--- a/SocialMediaApp.MVC/Views/_ViewImports.cshtml
+++ b/SocialMediaApp.MVC/Views/_ViewImports.cshtml
@@ -5,4 +5,5 @@
 @using SocialMediaApp.SharedModels;
 @using SocialMediaApp.MVC.Models.IndexModels;
 @using SocialMediaApp.DataAccessLibrary.Repositories;
+@using Microsoft.AspNetCore.Authentication;
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/SocialMediaApp.MVC/appsettings.json
+++ b/SocialMediaApp.MVC/appsettings.json
@@ -5,16 +5,9 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "AllowedHosts": "*",
   "ConnectionStrings": {
     "DefaultAuthentication": "Data Source=(localdb)\\MSSQLLocalDB;Database=SocialMediaAppAuthenticationDb;Integrated Security=True;Connect Timeout=30;Encrypt=False;Trust Server Certificate=False;Application Intent=ReadWrite;Multi Subnet Failover=False",
     "DefaultData": "Data Source=(localdb)\\MSSQLLocalDB;Database=SocialMediaAppDataDb;Integrated Security=True;Connect Timeout=30;Encrypt=False;Trust Server Certificate=False;Application Intent=ReadWrite;Multi Subnet Failover=False"
-  },
-  "AllowedHosts": "*",
-  "SmtpSettings": {
-    "Host": "smtp.gmail.com",
-    "Port": 587,
-    "Username": "kinnaskonstantinos0@gmail.com",
-    "Password": "icpawqjkdzkcoxgc",
-    "EnableSsl": true
   }
 }


### PR DESCRIPTION
After this update a user can sign in the application using google as their external identity provider. If they have already an account they can still sign in using google and that external sign in is applied to their account. If then they wish to change account and they are using google as then external identity provider then that login provider is removed and if there is no password, because they created the local account using google as their external provider, then a new temp password is created, so that they can log in. Some minor bugs have been fixed and more emphasis was given in security(email credentials removed from appsettings.json and changed).