### PR TITLE
Added Microsoft External Identity Provider - Closes Issue 54

### DIFF
--- a/SocialMediaApp.AuthenticationLibrary/SocialMediaApp.AuthenticationLibrary.csproj
+++ b/SocialMediaApp.AuthenticationLibrary/SocialMediaApp.AuthenticationLibrary.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="7.0.17" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="7.0.17" />
     <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.16" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.16" />

--- a/SocialMediaApp.MVC/Program.cs
+++ b/SocialMediaApp.MVC/Program.cs
@@ -61,6 +61,10 @@ public class Program
         {
             options.ClientId = configuration.GetValue<string>("Authentication:Google:ClientId")!;
             options.ClientSecret = configuration.GetValue<string>("Authentication:Google:ClientSecret")!;
+        }).AddMicrosoftAccount(options =>
+        {
+            options.ClientId = configuration.GetValue<string>("Authentication:Microsoft:ClientId")!;
+            options.ClientSecret = configuration.GetValue<string>("Authentication:Microsoft:ClientSecret")!;
         });
 
         builder.Services.AddScoped<IAuthenticationProcedures, AuthenticationProcedures>();

--- a/SocialMediaApp.MVC/Views/Account/EditAccount.cshtml
+++ b/SocialMediaApp.MVC/Views/Account/EditAccount.cshtml
@@ -162,8 +162,11 @@ else if (basicInformationChangeSuccess || passwordChangeSuccess || friendRemoval
                     }
                 </div>
                 <div class="col-12 mb-4 mt-1">
+                    @{
+                        string managedByExternalProvider = @Model!.ChangeEmailModel!.OldEmail!.Contains("@") ? "" : "- Managed By External Provider";
+                    }
                     <label class="form-label" asp-for="@Model.ChangeEmailModel.OldEmail">
-                        <i class="fa-solid fa-envelope me-2"></i>Account Email
+                        <i class="fa-solid fa-envelope me-2"></i>Account Email @managedByExternalProvider
                     </label>
                     <div class="input-group">
                         <input type="email" class="form-control" asp-for="@Model.ChangeEmailModel.OldEmail"
@@ -252,6 +255,12 @@ else if (basicInformationChangeSuccess || passwordChangeSuccess || friendRemoval
                             <svg class="bi flex-shrink-0 me-2" width="24" height="24" role="img" aria-label="Warning:"><use xlink:href="#exclamation-triangle-fill" /></svg>
                             <div>
                                 This action will log you out of your account and it will deactivate it until you confirm your new email.<br />
+                            </div>
+                        </div>
+                        <div class="alert alert-warning d-flex align-items-center" role="alert">
+                            <svg class="bi flex-shrink-0 me-2" width="24" height="24" role="img" aria-label="Warning:"><use xlink:href="#exclamation-triangle-fill" /></svg>
+                            <div>
+                                This action may also disconnect your account from your external identity provider(for example Google).<br />
                             </div>
                         </div>
                         <div class="row">

--- a/SocialMediaApp.MVC/Views/Account/SignIn.cshtml
+++ b/SocialMediaApp.MVC/Views/Account/SignIn.cshtml
@@ -82,17 +82,17 @@
                 <div id="external-service-providers" class="d-grid gap-2">
                     @foreach (AuthenticationScheme identityProvider in Model.ExternalIdentityProviders)
                     {
+                        string icon = identityProvider.Name switch
+                        {
+                            "Google" => "fa-google",
+                            "Microsoft" => "fa-microsoft",
+                            _ => ""
+                        };
                         <button class="btn text-start py-2 px-3" style="background-color:transparent;border: 1px solid #ced4da;" type="submit"
                             name="identityProviderName" value="@identityProvider.Name">
-                            <i class="fa-brands fa-google me-2"></i>Continue with @identityProvider.DisplayName
+                            <i class="fa-brands @icon me-2"></i>Continue with @identityProvider.DisplayName
                         </button>
                     }
-                    <button class="btn text-start py-2 px-3" style="background-color:transparent;border: 1px solid #ced4da;" type="button">
-                        <i class="fa-brands fa-microsoft me-2"></i>Continue with Microsoft
-                    </button>
-                    <button class="btn text-start py-2 px-3" style="background-color:transparent;border: 1px solid #ced4da;" type="button">
-                        <i class="fa-brands fa-square-facebook me-2"></i>Continue with Facebook
-                    </button>
                 </div>
                 <input name="returnUrl" value="@Model.ReturnUrl" hidden/>
             </form>


### PR DESCRIPTION
After this update a user can sign in the application using Microsoft as their external identity provider. If they have already an account they can still sign in using that account and then the external sign in is applied to that account seemlessly. The implementation is based mostly on the previous issue 53(add google as external identity provider) and thus only minor changes were made. Something that needs to be noted is that for some unknown reason only buisiness account are accepted through that method and personal hotmail accounts can not be used for this process. Hopefully this issue will be resolved in a future update.