### PR TITLE
Added Twitter External Identity Provider - Closes Issue 58

### DIFF
--- a/SocialMediaApp.AuthenticationLibrary/AuthenticationProcedures.cs
+++ b/SocialMediaApp.AuthenticationLibrary/AuthenticationProcedures.cs
@@ -445,7 +445,7 @@ public class AuthenticationProcedures : IAuthenticationProcedures
             return null!;
 
         string email = loginInfo.Principal.FindFirstValue(ClaimTypes.Email)! ?? loginInfo.Principal.FindFirstValue(ClaimTypes.NameIdentifier)!;
-        string username = loginInfo.Principal.FindFirstValue(ClaimTypes.Email)! ?? loginInfo.Principal.FindFirstValue(ClaimTypes.Surname)! + loginInfo.Principal.FindFirstValue(ClaimTypes.NameIdentifier)?.Substring(0, 5);
+        string username = loginInfo.Principal.FindFirstValue(ClaimTypes.Email)! ?? loginInfo.Principal.FindFirstValue(ClaimTypes.Name)! + loginInfo.Principal.FindFirstValue(ClaimTypes.NameIdentifier)?.Substring(0, 5);
         //if the returned information does not contain email give up
         if (email == null)
             return "email info of external identity provider was not received";

--- a/SocialMediaApp.AuthenticationLibrary/SocialMediaApp.AuthenticationLibrary.csproj
+++ b/SocialMediaApp.AuthenticationLibrary/SocialMediaApp.AuthenticationLibrary.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="7.0.17" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="7.0.17" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Twitter" Version="7.0.17" />
     <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.16" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.16" />

--- a/SocialMediaApp.MVC/Program.cs
+++ b/SocialMediaApp.MVC/Program.cs
@@ -65,6 +65,10 @@ public class Program
         {
             options.ClientId = configuration.GetValue<string>("Authentication:Microsoft:ClientId")!;
             options.ClientSecret = configuration.GetValue<string>("Authentication:Microsoft:ClientSecret")!;
+        }).AddTwitter(options =>
+        {
+            options.ConsumerKey = configuration.GetValue<string>("Authentication:Twitter:ClientId")!;
+            options.ConsumerSecret = configuration.GetValue<string>("Authentication:Twitter:ClientSecret")!;
         });
 
         builder.Services.AddScoped<IAuthenticationProcedures, AuthenticationProcedures>();

--- a/SocialMediaApp.MVC/Views/Account/SignIn.cshtml
+++ b/SocialMediaApp.MVC/Views/Account/SignIn.cshtml
@@ -86,6 +86,7 @@
                         {
                             "Google" => "fa-google",
                             "Microsoft" => "fa-microsoft",
+                            "Twitter" => "fa-square-x-twitter",
                             _ => ""
                         };
                         <button class="btn text-start py-2 px-3" style="background-color:transparent;border: 1px solid #ced4da;" type="submit"


### PR DESCRIPTION
After this update a user can sign in the application using Twitter as their external identity provider. The implementation is based mostly on the previous issue 53(add google as external identity provider) and thus only minor changes were made.