### PR TITLE
Small External Identity Providers Change In Appsettings

### DIFF
--- a/SocialMediaApp.MVC/appsettings.json
+++ b/SocialMediaApp.MVC/appsettings.json
@@ -15,5 +15,19 @@
   "ConnectionStrings": {
     "DefaultAuthentication": "Data Source=(localdb)\\MSSQLLocalDB;Database=SocialMediaAppAuthenticationDb;Integrated Security=True;Connect Timeout=30;Encrypt=False;Trust Server Certificate=False;Application Intent=ReadWrite;Multi Subnet Failover=False",
     "DefaultData": "Data Source=(localdb)\\MSSQLLocalDB;Database=SocialMediaAppDataDb;Integrated Security=True;Connect Timeout=30;Encrypt=False;Trust Server Certificate=False;Application Intent=ReadWrite;Multi Subnet Failover=False"
+  },
+  "Authentication": {
+    "Google": {
+      "ClientId": "bogusId",
+      "ClientSecret": "bogusSecret"
+    },
+    "Microsoft": {
+      "ClientId": "bogusId",
+      "ClientSecret": "bogusSecret"
+    },
+    "Twitter": {
+      "ClientId": "bogusId",
+      "ClientSecret": "bogusSecret"
+    }
   }
 }


### PR DESCRIPTION
I fixed a bug in which the application was crashing if the external authentication providers were not passed in the application as environmental variables or if they did not exist in the personal secrets.json. Now the application should not crash if the default values are not overriden through the file secrets.json or through environmental variables and only the external identity providers part of the application will not be funtional.